### PR TITLE
feat/register_skill_voc

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -42,6 +42,7 @@ class PyradiosSkill(OVOSCommonPlaybackSkill):
                 "res",
                 "radio-tuner-small.png"
             ),
+            skill_voc_filename="pyradios",
             *args,
             **kwargs
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ovos-utils >= 0.1.0a7
 ovos-bus-client>=0.0.9a1
-ovos-workshop>=0.0.16a3
+ovos-workshop>=0.0.16a43
 pyradios
 dead-simple-cache>=1.2.2
 rapidfuzz


### PR DESCRIPTION
OCP skills can now register a .voc file with ovos-core OCP pipeline. This allows requesting that a skill is searched by name

if a utterance contains "pyradios", ovos will only search this skill instead of doing a global search. If the skill does not return results a global search is still made

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new parameter `skill_voc_filename` to specify a skill vocabulary filename during initialization.

- **Chores**
  - Updated `ovos-workshop` dependency version to `0.0.16a43`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->